### PR TITLE
Address deprecated API removal in pytest 8.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,coverage-report
+envlist = py27,py36,py310,py311,coverage-report
 
 # [testenv]
 # deps = -rdev-requirements.txt
@@ -14,6 +14,18 @@ deps = -rdev-requirements.txt
 commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
 
 [testenv:py36]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py39]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py310]
+deps = -rdev-requirements.txt
+commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
+
+[testenv:py311]
 deps = -rdev-requirements.txt
 commands = coverage run --parallel --source=pytest_it -m pytest tests {posargs}
 


### PR DESCRIPTION
Use pathlib.Path:
https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path

Use @pytest.hookimpl(tryfirst=True) instead of @pytest.mark.tryfirst: https://docs.pytest.org/en/latest/deprecations.html#id3

Add py310 and py311 to tox envlist